### PR TITLE
Fixing Arity Deprication

### DIFF
--- a/addon/initializers/f7-service.js
+++ b/addon/initializers/f7-service.js
@@ -1,4 +1,5 @@
-export function initialize(registry, application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
   application.inject('route', 'f7', 'service:f7');
   application.inject('controller', 'f7', 'service:f7');
   application.inject('component', 'f7', 'service:f7');


### PR DESCRIPTION
In prior versions of Ember initializers have taken two arguments (generally labeled as container and application). Starting with Ember 2.1 providing two arguments to an initializer will trigger a deprecation.
